### PR TITLE
Make copying the nginx directory work with Mac terminal

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -217,7 +217,10 @@ echo "copying nginx files for $environment "
 echo "-----------------------------------------------------"
 
 echo "Loading $environment scripts"
-cp -fr ./envs/$environment/nginx/ .
+mkdir ./nginx
+cp -fr ./envs/$environment/nginx/sites-enabled ./nginx/
+cp -fr ./envs/$environment/nginx/Dockerfile ./nginx/Dockerfile
+cp -fr ./envs/$environment/nginx/nginx.conf ./nginx/nginx.conf
 cp -fr ./envs/$environment/docker-compose.yml ./docker-compose.yml
 cp -fr ./envs/$environment/requirements.txt ./requirements.txt
 cp -fr ./envs/$environment/nginx/ssl ./nginx/


### PR DESCRIPTION
@khueyama had to revert some of the changes you made to the deploy script. The recursive copy won't work on my computer. Also, the directory has to exist for the copy to work.